### PR TITLE
Revert "Update dependency kubernetes/kubernetes to v1.31.0"

### DIFF
--- a/apps/system-update-controller/base/kube-update-plan.yaml
+++ b/apps/system-update-controller/base/kube-update-plan.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: system-upgrade
 spec:
   # renovate: datasource=github-releases depName=kubernetes/kubernetes
-  version: v1.31.0
+  version: v1.30.3
   serviceAccountName: system-upgrade
   secrets:
     - name: talos

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -5,7 +5,7 @@ clusterName: invertedorigin
 talosVersion: v1.7.6
 
 # renovate: datasource=github-releases depName=kubernetes/kubernetes
-kubernetesVersion: v1.31.0
+kubernetesVersion: v1.30.3
 
 endpoint: https://node-1.tail7ebe0.ts.net:6443
 


### PR DESCRIPTION
Reverts invertedorigin/home-infra#801 1.31 is not currently a supported upgrade path for talos