### PR TITLE
Revert "Update Helm release rook-ceph-cluster to v1.16.0"

### DIFF
--- a/apps/rook-ceph/base/kustomization.yaml
+++ b/apps/rook-ceph/base/kustomization.yaml
@@ -17,7 +17,7 @@ helmCharts:
 
 - name: rook-ceph-cluster
   repo: https://charts.rook.io/release
-  version: v1.16.0
+  version: v1.15.6
   releaseName: rook-ceph-cluster
   namespace: rook-ceph
   valuesInLine:


### PR DESCRIPTION
Reverts invertedorigin/home-infra#1117