### PR TITLE
Revert "Update Helm release rook-ceph to v1.16.0"

### DIFF
--- a/apps/rook-ceph/base/kustomization.yaml
+++ b/apps/rook-ceph/base/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: rook-ceph
 helmCharts:
 - name: rook-ceph
   repo: https://charts.rook.io/release
-  version: v1.16.0
+  version: v1.15.6
   releaseName: rook-ceph
   valuesInLine:
     monitoring:


### PR DESCRIPTION
Reverts invertedorigin/home-infra#1116