### PR TITLE
Revert "Update Helm release tailscale-operator to v1.84.0"

### DIFF
--- a/apps/tailscale-operator/base/kustomization.yaml
+++ b/apps/tailscale-operator/base/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 helmCharts:
 - name: tailscale-operator
   repo: https://pkgs.tailscale.com/helmcharts
-  version: 1.84.0
+  version: 1.82.5
   releaseName: tailscale-operator
   namespace: tailscale-operator
   includeCRDs: true


### PR DESCRIPTION
Reverts invertedorigin/home-infra#1479