### PR TITLE
Revert "Update ghcr.io/kashalls/external-dns-unifi-webhook Docker tag to v0.6.1"

### DIFF
--- a/apps/external-dns/base/kustomization.yaml
+++ b/apps/external-dns/base/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
       webhook:
         image:
           repository: ghcr.io/kashalls/external-dns-unifi-webhook
-          tag: v0.6.1
+          tag: v0.6.0
         env:
           - name: UNIFI_HOST
             valueFrom:


### PR DESCRIPTION
Reverts invertedorigin/home-infra#1530