### PR TITLE
feat(rook-ceph): upgrade helm charts to v1.20.2 with ceph-csi-drivers migration

### DIFF
--- a/apps/rook-ceph/base/kustomization.yaml
+++ b/apps/rook-ceph/base/kustomization.yaml
@@ -9,19 +9,16 @@ namespace: rook-ceph
 helmCharts:
 - name: rook-ceph
   repo: https://charts.rook.io/release
-  version: v1.19.6
+  version: v1.20.2
   releaseName: rook-ceph-operator
   namespace: rook-ceph
   valuesInline:
     crds:
       enabled: true
     csi:
-      kubeletDirPath: /var/lib/kubelet
-      enableCSIHostNetwork: true
-      enableGrpcMetrics: true
-      enableCSIEncryption: false
-      csiAddons:
-        enabled: false
+      # v1.20: CSI drivers are managed by the ceph-csi-operator (installed as a
+      # subchart here); driver settings moved to the ceph-csi-drivers chart below
+      installCsiOperator: true
       serviceMonitor:
         enabled: true
     monitoring:
@@ -34,9 +31,43 @@ helmCharts:
         cpu: 1500m
         memory: 512Mi
 
+# Required as of v1.20, creates the Driver CRs consumed by the ceph-csi-operator.
+# Driver names must keep the rook-ceph namespace prefix to match the provisioner
+# names of existing PVs/StorageClasses/VolumeSnapshotClasses.
+- name: ceph-csi-drivers
+  repo: https://ceph.github.io/ceph-csi-operator
+  version: 1.0.4
+  releaseName: ceph-csi-drivers
+  namespace: rook-ceph
+  valuesInline:
+    operatorConfig:
+      namespace: rook-ceph
+      driverSpecDefaults:
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        nodePlugin:
+          priorityClassName: system-node-critical
+        controllerPlugin:
+          priorityClassName: system-cluster-critical
+          # preserve pre-v1.20 enableCSIHostNetwork behavior for the external cluster
+          hostNetwork: true
+    drivers:
+      rbd:
+        enabled: true
+        name: rook-ceph.rbd.csi.ceph.com
+      cephfs:
+        enabled: true
+        name: rook-ceph.cephfs.csi.ceph.com
+      nfs:
+        enabled: false
+        name: rook-ceph.nfs.csi.ceph.com
+      nvmeof:
+        enabled: false
+        name: rook-ceph.nvmeof.csi.ceph.com
+
 - name: rook-ceph-cluster
   repo: https://charts.rook.io/release
-  version: v1.19.6
+  version: v1.20.2
   releaseName: rook-ceph-cluster
   namespace: rook-ceph
   valuesInline:
@@ -77,3 +108,13 @@ patches:
     - op: add
       path: /metadata/annotations/argocd.argoproj.io~1sync-options
       value: ServerSideApply=true
+# The Driver CRs ship in the same app as their CRDs (new in v1.20), so the
+# first sync must not dry-run them before the CRDs exist
+- target:
+    group: csi.ceph.io
+    kind: Driver
+  patch: |-
+    - op: add
+      path: /metadata/annotations
+      value:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
## What changed

Bumps the Rook Ceph helm charts from v1.19.6 to v1.20.2 and handles the v1.20 breaking change: **the rook-ceph chart no longer deploys CSI drivers**. Drivers are now managed by the ceph-csi-operator (installed as a subchart of rook-ceph) and must be configured through the new, required `ceph-csi-drivers` chart.

- Bump `rook-ceph` and `rook-ceph-cluster` charts v1.19.6 → v1.20.2
- Drop CSI values removed from the rook-ceph chart (`kubeletDirPath`, `enableCSIHostNetwork`, `enableGrpcMetrics`, `enableCSIEncryption`, `csiAddons`); keep `csi.serviceMonitor.enabled: true` and set `csi.installCsiOperator: true` explicitly
- Add the `ceph-csi-drivers` chart at v1.0.4 (the exact ceph-csi-operator version pinned by rook-ceph v1.20.2) using [Rook's recommended values](https://raw.githubusercontent.com/rook/rook/v1.20.2/deploy/charts/ceph-csi-drivers/values.yaml), with NFS/NVMe-oF drivers explicitly disabled (chart defaults them **on**)
- Set `controllerPlugin.hostNetwork: true` to preserve the previous `enableCSIHostNetwork: true` behavior — the external Ceph mons live outside the pod network
- Annotate the new `Driver` CRs with `SkipDryRunOnMissingResource=true` since their CRDs arrive in the same ArgoCD sync (via the csi-operator subchart)

## Why the driver names matter

The Driver CRs keep the operator-namespace prefix (`rook-ceph.rbd.csi.ceph.com`, `rook-ceph.cephfs.csi.ceph.com`) so existing PVs, StorageClasses, and the `ceph-rbd-snapshot` VolumeSnapshotClass continue resolving to the same provisioners. Verified in the rendered output that the VolumeSnapshotClass still points at `rook-ceph.rbd.csi.ceph.com`.

Rook creates the `CephConnection`/`ClientProfile` CRs itself from the external CephCluster, so the drivers chart's empty defaults correctly render none.

## Reviewer notes

- Upgrade prerequisite satisfied: Rook requires ≥ v1.19.5 before moving to v1.20 (we're on v1.19.6)
- **Kubernetes ≥ v1.31 is now the minimum supported version** — confirm the cluster is there before syncing
- Validated locally with `kustomize build --enable-helm` on the core-infra overlay: 109 resources render, including the two Driver CRs, the `ceph-csi-operator-config` OperatorConfig, and the `rook-csi-operator-image-set-configmap` referenced by `driverSpecDefaults.imageSet`
- Expect CSI pods to restart under the new operator during the first sync
- Upstream references: [Rook v1.20 upgrade guide](https://rook.io/docs/rook/v1.20/Upgrade/rook-upgrade/), [CSI drivers chart](https://rook.io/docs/rook/v1.20/Helm-Charts/csi-drivers-chart/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)