### PR TITLE
fix(rook-ceph): stamp namespace on helm-generated RBAC and ServiceAccounts

### DIFF
--- a/apps/rook-ceph/base/kustomization.yaml
+++ b/apps/rook-ceph/base/kustomization.yaml
@@ -118,3 +118,26 @@ patches:
       path: /metadata/annotations
       value:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+# kustomize 5.8 (bundled with ArgoCD 3.4) no longer stamps the kustomization
+# namespace onto helm-generated resources that omit metadata.namespace
+# (kubernetes-sigs/kustomize#6058); several ceph-csi RBAC templates omit it
+- target:
+    kind: ServiceAccount
+  patch: |-
+    - op: add
+      path: /metadata/namespace
+      value: rook-ceph
+- target:
+    group: rbac.authorization.k8s.io
+    kind: Role
+  patch: |-
+    - op: add
+      path: /metadata/namespace
+      value: rook-ceph
+- target:
+    group: rbac.authorization.k8s.io
+    kind: RoleBinding
+  patch: |-
+    - op: add
+      path: /metadata/namespace
+      value: rook-ceph


### PR DESCRIPTION
## What changed

Follow-up to #1994. ArgoCD reports `InvalidSpecError: Namespace for ... is missing` on the core-infra-rook-ceph app for the ceph-csi ServiceAccount and the four Role/RoleBinding pairs of the RBD/CephFS drivers.

## Root cause

ArgoCD 3.4 bundles kustomize 5.8.1, which regressed the `namespace:` transformer: it no longer stamps the kustomization namespace onto helm-generated resources that omit `metadata.namespace` (kubernetes-sigs/kustomize#6058). The `ceph-csi-drivers` Role/RoleBinding templates and the ceph-csi-operator subchart's ServiceAccount don't set a namespace, and the core-infra ApplicationSet template sets no `destination.namespace`, so ArgoCD has nothing to fall back on. Local validation in #1994 used kustomize 5.2.1, which still stamped the namespace — masking the issue.

## Fix

Add JSON patches stamping `metadata.namespace: rook-ceph` onto ServiceAccount, Role, and RoleBinding resources. Every such resource in this app already belongs in rook-ceph, and the patch is a no-op under older kustomize versions that still apply the transformer.

Verified with kustomize v5.8.1 (`kustomize build --enable-helm`): all 109 resources now render with a namespace; RoleBinding subjects already carried the correct namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)