### PR TITLE
feat(renovate): automerge cloudflared updates and Argo CD patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -198,6 +198,32 @@
       ],
       "groupName": "all kube upgrades",
       "groupSlug": "all-k8s-upgrades"
+    },
+    {
+      "description": "Automerge all cloudflared version updates",
+      "matchPackageNames": [
+        "docker.io/cloudflare/cloudflared"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "ignoreTests": false
+    },
+    {
+      "description": "Automerge Argo CD patch updates (overrides the cluster-critical rule above; major/minor still require review)",
+      "matchPackageNames": [
+        "argoproj/argo-cd"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "ignoreTests": false
     }
   ]
 }


### PR DESCRIPTION
## What changed

Two new `packageRules` appended to `renovate.json`:

- **cloudflared** (`docker.io/cloudflare/cloudflared`): automerge all version updates (major/minor/patch). Digest updates stay manual via the existing "do not automerge Docker digest updates" rule.
- **Argo CD** (`argoproj/argo-cd`): automerge **patch** updates only (e.g. v3.4.3 → v3.4.4).

## Reviewer notes

- `argoproj/argo-cd` is on the "Never automerge cluster-critical components" list. Renovate applies packageRules last-match-wins, so these rules are appended at the end: the new rule flips automerge on for Argo CD patches while major/minor updates keep requiring manual review.
- Both rules use `automergeType: pr` with `ignoreTests: false`, matching the existing automerge rules, so CI must pass before Renovate merges.
- Package names verified against recent Renovate PRs (#1997 cloudflared, #1979 argoproj/argo-cd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)